### PR TITLE
Update runivy-export.cmd

### DIFF
--- a/runivy-export.cmd
+++ b/runivy-export.cmd
@@ -1,3 +1,3 @@
 rm userlib/*
 java -jar build\apache-ivy-2.4.0\ivy-2.4.0.jar -ivy ivy.xml -confs export -retrieve "userlib/[artifact]-[revision].[ext]"
-for %%f in (userlib\*) do touch %%f-SlackConnector
+for %%f in (userlib\*) do touch %%f.SlackConnector.RequiredLib


### PR DESCRIPTION
I got errors where OSGI complained about empty files with extension .jar-SlackConnector
